### PR TITLE
Show noResultsInfo too when there is no data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-bootstrap-components/vue-bootstrap-autocomplete",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "private": false,
   "description": "A typeahead/autocomplete component for Vue 2 using Bootstrap 4",
   "keywords": [

--- a/src/components/VueBootstrapAutocomplete.vue
+++ b/src/components/VueBootstrapAutocomplete.vue
@@ -49,7 +49,7 @@
       :id="`result-list-${id}`"
       class="vbt-autocomplete-list"
       ref="list"
-      v-show="isFocused && data.length > 0"
+      v-show="isFocused && (data.length > 0 || !!$scopedSlots.noResultsInfo || !!noResultsInfo)"
       :query="inputValue"
       :data="formattedData"
       :background-variant="backgroundVariant"

--- a/tests/unit/VueTypeaheadBootstrap.spec.js
+++ b/tests/unit/VueTypeaheadBootstrap.spec.js
@@ -199,7 +199,9 @@ describe('VueBootstrapAutocomplete', () => {
       await input.trigger('paste')
       expect(wrapper.emitted().paste).toBeTruthy()
     })
+  })
 
+  describe('No results info prop and template', () => {
     it('Shows a "No results found for Canada" when the noResultsInfo prop has been set and there are no results', async () => {
       wrapper = mount({
         components: {
@@ -389,5 +391,75 @@ describe('VueBootstrapAutocomplete', () => {
       expect(child.text()).toBe('No results found using the template')
       expect(wrapper.text()).not.toContain('No results found using the prop')
     })
-  })
+
+    it('Shows the "No results found" message when the noResultsInfo prop has been set and there is no data', async () => {
+      wrapper = mount({
+        components: {
+          VueBootstrapAutocomplete
+        },
+        data() {
+          return {
+            data: [],
+            query: ''
+          }
+        },
+        template: `
+          <vue-bootstrap-autocomplete
+            :data="data"
+            v-model="query"
+            no-results-info="No results found"
+          />
+          </vue-bootstrap-autocomplete>
+        `
+      })
+
+      const child = wrapper.findComponent(VueBootstrapAutocompleteList)
+
+      expect(child.isVisible()).toBe(false)
+      wrapper.find('input').setValue('Cadana')
+
+      await wrapper.vm.$nextTick()
+      expect(child.isVisible()).toBe(true)
+      expect(wrapper.vm.$data.query).toBe('Cadana')
+      expect(child.text()).toBe('No results found')
+    });
+
+    it('Shows the "No results found" message when the noResultsInfo slot has been set and there is no data', async () => {
+      wrapper = mount({
+        components: {
+          VueBootstrapAutocomplete
+        },
+        data() {
+          return {
+            data: [],
+            query: ''
+          }
+        },
+        template: `
+          <vue-bootstrap-autocomplete
+            :data="data"
+            v-model="query"
+          >
+            <template #noResultsInfo>
+              <span>No results found</span>
+            </template>
+          </vue-bootstrap-autocomplete>
+        `
+      })
+
+      const child = wrapper.findComponent(VueBootstrapAutocompleteList)
+      const slot = wrapper.find('#noResultsInfo')
+
+      expect(child.isVisible()).toBe(false)
+      expect(slot.isVisible()).toBe(false)
+      wrapper.find('input').setValue('Cadana')
+
+      await wrapper.vm.$nextTick()
+      expect(child.isVisible()).toBe(true)
+      expect(slot.isVisible()).toBe(true)
+      expect(wrapper.vm.$data.query).toBe('Cadana')
+      expect(slot.text()).toBe('No results found')
+      expect(child.text()).toBe('No results found')
+    });
+  });
 })


### PR DESCRIPTION
The `noResultsInfo` prop or slot is not shown when there is no data. To allow using `noResultsInfo` with data that is being fetched asynchronously - perhaps there is an endpoint that returns (no) data based on the search term - `noResultsInfo` will always show when there are no matches. This will give the user of the component more control in whether `noResultsInfo` should be visible or not.