### PR TITLE
Fix vue warn htmlText

### DIFF
--- a/src/components/VueBootstrapAutocompleteList.vue
+++ b/src/components/VueBootstrapAutocompleteList.vue
@@ -125,6 +125,10 @@ export default {
     highlightClass: {
       type: String,
       default: 'vbt-matched-text'
+    },
+    htmlText: {
+      type: String,
+      default: ''
     }
   },
 


### PR DESCRIPTION
Issue:
When using `#noResultsInfo` template the console is flooded with vue warn errors.

![image](https://user-images.githubusercontent.com/47742106/228784323-2432cb49-7076-4295-98f4-19cb25845d84.png)

Defining to resolve.
