### PR TITLE
Bugfix: Select list items on enter keypress

### DIFF
--- a/src/components/VueBootstrapAutocompleteListItem.vue
+++ b/src/components/VueBootstrapAutocompleteListItem.vue
@@ -4,6 +4,7 @@
     @keydown.esc.stop.prevent="$emit('listItemBlur')"
     @keydown.down.prevent
     @keydown.up.prevent
+    @keyup.enter="$parent.hitActiveListItem($event)"
     @keyup.down="$parent.selectNextListItem($event)"
     @keyup.up="$parent.selectPreviousListItem($event)"
     @blur="processFocusOut"


### PR DESCRIPTION
Selecting highlighted items from the dropdown list using the enter key wasn't working.