### PR TITLE
Fix list hiding on scrollbar click

### DIFF
--- a/src/components/VueBootstrapAutocomplete.vue
+++ b/src/components/VueBootstrapAutocomplete.vue
@@ -260,6 +260,9 @@ export default {
       if (tgt && tgt.classList.contains('vbst-item')) {
         return
       }
+      if (this.$refs.list.$el.matches(':hover')) {
+        return
+      }
       this.$emit('blur', evt)
       this.isFocused = false
     },


### PR DESCRIPTION
When you try to scroll the autocomplete list via the scrollbar, the list closes.
This fixes this behaviour, with the caveat that blur closing won't work after scrolling via scrollbar.